### PR TITLE
Fix read tiles list

### DIFF
--- a/app/src/main/java/pifloor/processing/CalibrationModeActivity.kt
+++ b/app/src/main/java/pifloor/processing/CalibrationModeActivity.kt
@@ -81,18 +81,11 @@ class CalibrationModeActivity : AppCompatActivity(), OcrCaptureFragment.OcrSelec
         })
     }
 
-    private fun removeTile(str : String): Int {
-        val pos = captureFragment.tiles!!.indexOf(str)
+    private fun removeTile(str: String) {
+        val position = captureFragment.tiles!!.indexOf(str)
         captureFragment.tiles!!.remove(str)
-        captureFragment.adapter!!.notifyItemRemoved(pos)
-        /*var g : OcrGraphic? = graphicOverlay.getByContent(str)
-        if (g != null) {
-            g.getRectPaint().color = Color.WHITE
-            g.getTextPaint().color = Color.WHITE
-            graphicOverlay.remove(g)
-        }*/
-        virtualGrid.removeTile(captureFragment.graphicOverlay.getByContent(str).textBlock)
-        return pos
+        captureFragment.adapter!!.notifyItemRemoved(position)
+        virtualGrid.removeTile(str)
     }
 
     private fun displaySnackbar(text: String?, actionName: String?, action: View.OnClickListener?) {

--- a/app/src/main/java/pifloor/processing/CalibrationModeActivity.kt
+++ b/app/src/main/java/pifloor/processing/CalibrationModeActivity.kt
@@ -4,7 +4,6 @@ package pifloor.processing
 import android.content.Intent
 import android.hardware.Camera
 import android.os.Bundle
-import android.support.design.widget.FloatingActionButton
 import android.support.design.widget.Snackbar
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
@@ -19,6 +18,8 @@ import butterknife.ButterKnife
 import butterknife.OnClick
 import co.dift.ui.SwipeToAction
 import com.google.android.gms.vision.text.TextBlock
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 import pifloor.R
 import pifloor.graphcis.CalibratedOcrGraphic
 import pifloor.graphcis.OcrGraphic
@@ -26,8 +27,6 @@ import pifloor.graphcis.PreviewOcrGraphic
 import pifloor.injection.PiFloorApplication
 import pifloor.ui.camera.OcrGraphicOverlay
 import pifloor.utils.VirtualGrid
-import org.reactivestreams.Subscriber
-import org.reactivestreams.Subscription
 import javax.inject.Inject
 
 class CalibrationModeActivity : AppCompatActivity(), OcrCaptureFragment.OcrSelectionListener, Subscriber<ArrayList<TextBlock>> {
@@ -46,7 +45,6 @@ class CalibrationModeActivity : AppCompatActivity(), OcrCaptureFragment.OcrSelec
     public override fun onCreate(icicle: Bundle?) {
         super.onCreate(icicle)
         setContentView(R.layout.activity_calibrate_mode)
-        //actionBar?.setDisplayHomeAsUpEnabled(true)
         mTopToolbar = findViewById(R.id.my_toolbar)
         setSupportActionBar(mTopToolbar)
         ButterKnife.bind(this)
@@ -89,10 +87,10 @@ class CalibrationModeActivity : AppCompatActivity(), OcrCaptureFragment.OcrSelec
     }
 
     private fun displaySnackbar(text: String?, actionName: String?, action: View.OnClickListener?) {
-        var snack: Snackbar = Snackbar.make(findViewById(android.R.id.content), text!!, Snackbar.LENGTH_LONG)
+        val snack: Snackbar = Snackbar.make(findViewById(android.R.id.content), text!!, Snackbar.LENGTH_LONG)
                 .setAction(actionName, action)
 
-        var v: View = snack.view
+        val v: View = snack.view
         v.setBackgroundColor(resources.getColor(R.color.green))
         snack.show()
     }

--- a/app/src/main/java/pifloor/processing/CalibrationModeActivity.kt
+++ b/app/src/main/java/pifloor/processing/CalibrationModeActivity.kt
@@ -35,16 +35,13 @@ class CalibrationModeActivity : AppCompatActivity(), OcrCaptureFragment.OcrSelec
     lateinit var virtualGrid: VirtualGrid
     private lateinit var captureFragment: OcrCaptureFragment
 
-    @BindView(R.id.btn_startGame_calibrationModeActivity)
-    lateinit var startGameButton : FloatingActionButton
-
-    var mTopToolbar : Toolbar? = null
-    var focus :Boolean = false
-    var flash :Boolean = false
+    var mTopToolbar: Toolbar? = null
+    var focus: Boolean = false
+    var flash: Boolean = false
 
     @BindView(R.id.recycler)
     lateinit var recyclerView: RecyclerView
-    var swipeToAction : SwipeToAction? = null
+    var swipeToAction: SwipeToAction? = null
 
     public override fun onCreate(icicle: Bundle?) {
         super.onCreate(icicle)
@@ -59,10 +56,10 @@ class CalibrationModeActivity : AppCompatActivity(), OcrCaptureFragment.OcrSelec
     }
 
     private fun loadList() {
-        var layoutManager = LinearLayoutManager(this)
-        recyclerView.setLayoutManager(layoutManager)
+        val layoutManager = LinearLayoutManager(this)
+        recyclerView.layoutManager = layoutManager
         recyclerView.setHasFixedSize(true)
-        recyclerView.setAdapter(captureFragment.adapter)
+        recyclerView.adapter = captureFragment.adapter
 
         swipeToAction = SwipeToAction(recyclerView, object : SwipeToAction.SwipeListener<String> {
             override fun onClick(itemData: String?) {
@@ -85,7 +82,7 @@ class CalibrationModeActivity : AppCompatActivity(), OcrCaptureFragment.OcrSelec
     }
 
     private fun removeTile(str : String): Int {
-        var pos = captureFragment.tiles!!.indexOf(str)
+        val pos = captureFragment.tiles!!.indexOf(str)
         captureFragment.tiles!!.remove(str)
         captureFragment.adapter!!.notifyItemRemoved(pos)
         /*var g : OcrGraphic? = graphicOverlay.getByContent(str)
@@ -99,11 +96,11 @@ class CalibrationModeActivity : AppCompatActivity(), OcrCaptureFragment.OcrSelec
     }
 
     private fun displaySnackbar(text: String?, actionName: String?, action: View.OnClickListener?) {
-        var snack : Snackbar = Snackbar.make(findViewById(android.R.id.content), text!!, Snackbar.LENGTH_LONG)
+        var snack: Snackbar = Snackbar.make(findViewById(android.R.id.content), text!!, Snackbar.LENGTH_LONG)
                 .setAction(actionName, action)
 
-        var v : View = snack.getView()
-        v.setBackgroundColor(getResources().getColor(R.color.green))
+        var v: View = snack.view
+        v.setBackgroundColor(resources.getColor(R.color.green))
         snack.show()
     }
 
@@ -226,7 +223,7 @@ class CalibrationModeActivity : AppCompatActivity(), OcrCaptureFragment.OcrSelec
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        val id = item.getItemId()
+        val id = item.itemId
 
         if (id == R.id.flash) {
             if (!flash) {
@@ -239,7 +236,7 @@ class CalibrationModeActivity : AppCompatActivity(), OcrCaptureFragment.OcrSelec
                 captureFragment.mCameraSource!!.flashMode = Camera.Parameters.FLASH_MODE_OFF
             }
             return true
-        } else if(id == R.id.focus) {
+        } else if (id == R.id.focus) {
             if (!focus) {
                 focus = true
                 item.setIcon(R.drawable.focus_on)

--- a/app/src/main/java/pifloor/utils/VirtualGrid.kt
+++ b/app/src/main/java/pifloor/utils/VirtualGrid.kt
@@ -8,7 +8,7 @@ import com.google.android.gms.vision.text.TextBlock
 import java.util.*
 
 class VirtualGrid {
-    private val tiles = HashSet<GridTile>()
+    private val tiles = mutableSetOf<GridTile>()
     private val timeFilter = TimeFilter<String>(CHOICE_COOL_DOWN)
     val size
         get() = tiles.size
@@ -20,8 +20,8 @@ class VirtualGrid {
         return tiles.add(GridTile(tile))
     }
 
-    fun removeTile(tile: Text): Boolean {
-        return tiles.remove(GridTile(tile))
+    fun removeTile(text: String): Boolean {
+        return tiles.removeAll { i -> i.value == text }
     }
 
     fun contains(tile: Text): Boolean {
@@ -88,34 +88,22 @@ class VirtualGrid {
      * Instantiating an instance of a [Text] is not possible, this class
      * gives us this ability (just a wrapper class)
      */
-    private data class GridTile(private val textItem: Text) : Text {
-        private val textBoundingBox: Rect = textItem.boundingBox
-        private val textComponents: MutableList<out Text> = textItem.components
-        private val textCornerPoints: Array<Point> = textItem.cornerPoints
-        private val textValue: String = VirtualGrid.preProcess(textItem.value)
-
-        override fun getBoundingBox(): Rect {
-            return textBoundingBox
-        }
-
-        override fun getComponents(): MutableList<out Text> {
-            return textComponents
-        }
-
-        override fun getCornerPoints(): Array<Point> {
-            return textCornerPoints
-        }
-
-        override fun getValue(): String {
-            return textValue
-        }
+    private data class GridTile(private val textItem: Text) {
+        val textBoundingBox: Rect
+            get() = textItem.boundingBox
+        val components: MutableList<out Text>
+            get() = textItem.components
+        val cornerPoints: Array<Point>
+            get() = textItem.cornerPoints
+        val value: String
+            get() = VirtualGrid.preProcess(textItem.value)
 
         fun getCenter(): Point {
             return Point(textBoundingBox.centerX(), textBoundingBox.centerY())
         }
 
         override fun hashCode(): Int {
-            return textValue.hashCode()
+            return value.hashCode()
         }
 
         override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
Read tiles were not functional. This fixes it by removing the modifications that occurred after it (unfortunately).

Null pointer exception was caused when the user removes a read tile that its OcrGraphic was removed. i.e. the user read a value and calibrated it then moved their hands away from the text then swiped the old read value.